### PR TITLE
fix: Remove duplicate chevron from item rows

### DIFF
--- a/Cubby/Views/Items/ItemRow.swift
+++ b/Cubby/Views/Items/ItemRow.swift
@@ -64,10 +64,6 @@ struct ItemRow: View {
                 }
                 
                 Spacer()
-                
-                Image(systemName: "chevron.right")
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
             }
             .padding(.vertical, 8)
             .padding(.horizontal)


### PR DESCRIPTION
Fixes issue where NavigationLink's automatic chevron was combined with manual chevron.right image, causing double chevrons to appear.

NavigationLink now handles the disclosure indicator automatically.

Fixes #8