### PR TITLE
Fix location nesting order

### DIFF
--- a/Cubby/Views/Home/LocationSectionHeader.swift
+++ b/Cubby/Views/Home/LocationSectionHeader.swift
@@ -26,7 +26,7 @@ struct LocationSectionHeader: View {
 
             // Subtitle path (ancestors only)
             if segments.count > 1 {
-                let ancestors = Array(segments.dropLast())
+                let ancestors = Array(segments.dropLast().reversed())
                 HStack(spacing: 4) {
                     Image(systemName: "arrow.turn.down.right")
                         .renderingMode(.template)


### PR DESCRIPTION
Reverses the order of ancestor locations in the section header to show the immediate parent first, improving readability.