### PR TITLE
Add Xcode Cloud preflight skill

### DIFF
--- a/.agents/skills/cubby-xcloud-pr-preflight/SKILL.md
+++ b/.agents/skills/cubby-xcloud-pr-preflight/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: cubby-xcloud-pr-preflight
+description: Use before opening, updating, pushing, or uploading any Cubby PR or branch that can trigger Xcode Cloud, TestFlight, or App Store Connect distribution. Checks Cubby's MARKETING_VERSION and CURRENT_PROJECT_VERSION against App Store Connect version-train state and uploaded build numbers, with special handling for codex/ PR branches, direct TestFlight uploads, Xcode Cloud failures, Apple validation errors 90186/90062, and build-number/version-train bumps.
+---
+
+# Cubby Xcode Cloud PR Preflight
+
+## Required Flow
+
+Run this skill before pushing a branch that can trigger Cubby's Xcode Cloud workflow, before direct TestFlight upload, and before "fixing" Xcode Cloud by bumping a build number.
+
+1. Use repo root `/Users/barron/Developer/Cubby` or the active Cubby worktree.
+2. Run the checker:
+
+```bash
+python3 .agents/skills/cubby-xcloud-pr-preflight/scripts/preflight.py
+```
+
+For direct local TestFlight upload, use:
+
+```bash
+python3 .agents/skills/cubby-xcloud-pr-preflight/scripts/preflight.py --direct-upload
+```
+
+3. Treat any `BLOCKED` line as a stop sign. Fix the project version/build settings first, then run the checker again.
+4. After pushing, monitor the PR check:
+
+```bash
+gh pr checks --watch=false
+```
+
+If Xcode Cloud fails, inspect the check details before making another version bump.
+
+## Rules
+
+- Always set `ASC_BYPASS_KEYCHAIN=1` for `asc` commands in this repo.
+- App Store Connect app ID is `6751732388`.
+- Read version values from `Cubby.xcodeproj/project.pbxproj`; all `MARKETING_VERSION` values must match, and all `CURRENT_PROJECT_VERSION` values must match.
+- Check the App Store version train first. If the project `MARKETING_VERSION` already has an App Store version in `READY_FOR_DISTRIBUTION` or `READY_FOR_SALE`, that train is closed for new TestFlight uploads. Bump `MARKETING_VERSION` to the next patch version before pushing or uploading.
+- Then check build numbers. For direct TestFlight uploads, `CURRENT_PROJECT_VERSION` must be greater than every uploaded build number for the same `MARKETING_VERSION`.
+- Xcode Cloud may assign its own build number. Do not assume the Xcode Cloud build number will equal `CURRENT_PROJECT_VERSION`; still keep the project value sane for local/direct uploads.
+- Do not push a no-op build bump until ASC confirms whether the failure is a closed version train, an actual build-number collision, or something else.
+- Keep PR branches that should trigger the Codex Xcode Cloud/TestFlight workflow under the `codex/` prefix.
+
+## Failure Signals
+
+- Apple validation errors `90186` or `90062` usually mean the archive was uploaded to a closed or invalid version train. Check `MARKETING_VERSION` before bumping only `CURRENT_PROJECT_VERSION`.
+- Xcode Cloud "Preparing build for App Store Connect failed" can be the same closed-train problem. Verify ASC version state and build history before changing project settings.
+- If `asc` asks for keychain access, the environment is wrong. Use `ASC_BYPASS_KEYCHAIN=1` and the exported config/key files already set up on this machine.

--- a/.agents/skills/cubby-xcloud-pr-preflight/agents/openai.yaml
+++ b/.agents/skills/cubby-xcloud-pr-preflight/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Cubby Xcode Cloud Preflight"
+  short_description: "Check Cubby PR versioning before Xcode Cloud or TestFlight."
+  default_prompt: "Run the Cubby Xcode Cloud preflight before pushing or uploading this PR."

--- a/.agents/skills/cubby-xcloud-pr-preflight/scripts/preflight.py
+++ b/.agents/skills/cubby-xcloud-pr-preflight/scripts/preflight.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Preflight Cubby App Store versioning before Xcode Cloud/TestFlight."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+CLOSED_VERSION_STATES = {
+    "READY_FOR_DISTRIBUTION",
+    "READY_FOR_SALE",
+    "DEVELOPER_REMOVED_FROM_SALE",
+    "REMOVED_FROM_SALE",
+}
+
+
+def run_json(command: list[str]) -> dict[str, Any]:
+    env = os.environ.copy()
+    env.setdefault("ASC_BYPASS_KEYCHAIN", "1")
+    proc = subprocess.run(
+        command,
+        check=False,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"{' '.join(command)} failed with exit {proc.returncode}:\n{proc.stderr.strip()}"
+        )
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{' '.join(command)} did not return JSON: {exc}") from exc
+
+
+def parse_project(project_file: Path) -> tuple[str, str, list[str]]:
+    if not project_file.exists():
+        raise RuntimeError(f"Project file not found: {project_file}")
+
+    values: dict[str, set[str]] = {
+        "MARKETING_VERSION": set(),
+        "CURRENT_PROJECT_VERSION": set(),
+    }
+    pattern = re.compile(r"\b(MARKETING_VERSION|CURRENT_PROJECT_VERSION)\s*=\s*([^;]+);")
+
+    for line in project_file.read_text(encoding="utf-8").splitlines():
+        match = pattern.search(line)
+        if match:
+            key, value = match.groups()
+            values[key].add(value.strip().strip('"'))
+
+    notes: list[str] = []
+    for key, found in values.items():
+        if not found:
+            raise RuntimeError(f"{key} was not found in {project_file}")
+        if len(found) > 1:
+            notes.append(f"BLOCKED: {key} has multiple values: {', '.join(sorted(found))}")
+
+    marketing = next(iter(values["MARKETING_VERSION"]))
+    build = next(iter(values["CURRENT_PROJECT_VERSION"]))
+    return marketing, build, notes
+
+
+def version_sort_key(version: str) -> tuple[int, ...]:
+    parts = []
+    for part in version.split("."):
+        try:
+            parts.append(int(part))
+        except ValueError:
+            parts.append(0)
+    return tuple(parts)
+
+
+def next_patch_version(version: str) -> str:
+    parts = version.split(".")
+    if not parts:
+        return version
+    try:
+        parts[-1] = str(int(parts[-1]) + 1)
+    except ValueError:
+        return f"{version}.1"
+    return ".".join(parts)
+
+
+def app_store_versions(app_id: str) -> list[dict[str, Any]]:
+    payload = run_json(
+        [
+            "asc",
+            "versions",
+            "list",
+            "--app",
+            app_id,
+            "--platform",
+            "IOS",
+            "--limit",
+            "200",
+            "--output",
+            "json",
+        ]
+    )
+    data = payload.get("data", [])
+    return data if isinstance(data, list) else []
+
+
+def builds(app_id: str) -> tuple[list[dict[str, Any]], dict[str, str]]:
+    payload = run_json(
+        [
+            "asc",
+            "builds",
+            "list",
+            "--app",
+            app_id,
+            "--sort",
+            "-uploadedDate",
+            "--limit",
+            "200",
+            "--output",
+            "json",
+        ]
+    )
+    data = payload.get("data", [])
+    included = payload.get("included", [])
+    prerelease_versions: dict[str, str] = {}
+    for item in included if isinstance(included, list) else []:
+        if item.get("type") == "preReleaseVersions":
+            attrs = item.get("attributes", {})
+            version = attrs.get("version")
+            if version:
+                prerelease_versions[item["id"]] = version
+    return (data if isinstance(data, list) else []), prerelease_versions
+
+
+def build_numbers_for_version(
+    build_items: list[dict[str, Any]],
+    prerelease_versions: dict[str, str],
+    marketing_version: str,
+) -> list[int]:
+    numbers: list[int] = []
+    for item in build_items:
+        attrs = item.get("attributes", {})
+        relationships = item.get("relationships", {})
+        prerelease = relationships.get("preReleaseVersion", {}).get("data", {})
+        prerelease_id = prerelease.get("id")
+        if prerelease_versions.get(prerelease_id) != marketing_version:
+            continue
+        raw_version = attrs.get("version")
+        try:
+            numbers.append(int(str(raw_version)))
+        except (TypeError, ValueError):
+            continue
+    return sorted(numbers)
+
+
+def int_or_none(value: str) -> int | None:
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check Cubby project versioning against App Store Connect before Xcode Cloud/TestFlight."
+    )
+    parser.add_argument("--app", default="6751732388", help="App Store Connect app ID.")
+    parser.add_argument(
+        "--project",
+        default="Cubby.xcodeproj/project.pbxproj",
+        help="Path to Cubby's project.pbxproj.",
+    )
+    parser.add_argument(
+        "--direct-upload",
+        action="store_true",
+        help="Fail if CURRENT_PROJECT_VERSION is not greater than existing builds for this marketing version.",
+    )
+    parser.add_argument(
+        "--skip-asc",
+        action="store_true",
+        help="Only validate local project version consistency.",
+    )
+    args = parser.parse_args()
+
+    project_file = Path(args.project)
+    marketing_version, build_version, messages = parse_project(project_file)
+    print(f"Project MARKETING_VERSION: {marketing_version}")
+    print(f"Project CURRENT_PROJECT_VERSION: {build_version}")
+
+    if not args.skip_asc:
+        versions = app_store_versions(args.app)
+        matching_versions = [
+            item
+            for item in versions
+            if item.get("attributes", {}).get("versionString") == marketing_version
+        ]
+        latest_app_store_version = max(
+            (
+                item.get("attributes", {}).get("versionString", "0")
+                for item in versions
+                if item.get("attributes", {}).get("versionString")
+            ),
+            key=version_sort_key,
+            default=None,
+        )
+
+        if latest_app_store_version:
+            print(f"Latest App Store version record: {latest_app_store_version}")
+
+        for item in matching_versions:
+            attrs = item.get("attributes", {})
+            states = {
+                str(attrs.get("appVersionState", "")),
+                str(attrs.get("appStoreState", "")),
+            }
+            states.discard("")
+            print(f"ASC version train {marketing_version}: {', '.join(sorted(states))}")
+            if states & CLOSED_VERSION_STATES:
+                suggested = next_patch_version(marketing_version)
+                messages.append(
+                    "BLOCKED: MARKETING_VERSION points at a closed App Store version train. "
+                    f"Bump MARKETING_VERSION to {suggested} or the next intended release train."
+                )
+
+        build_items, prerelease_versions = builds(args.app)
+        current_builds = build_numbers_for_version(
+            build_items, prerelease_versions, marketing_version
+        )
+        if current_builds:
+            max_build = max(current_builds)
+            print(f"Highest uploaded build for {marketing_version}: {max_build}")
+            project_build = int_or_none(build_version)
+            if project_build is None:
+                messages.append(
+                    "BLOCKED: CURRENT_PROJECT_VERSION is not numeric; App Store uploads need a numeric build."
+                )
+            elif args.direct_upload and project_build <= max_build:
+                messages.append(
+                    "BLOCKED: direct TestFlight upload would reuse or go below an uploaded build number. "
+                    f"Set CURRENT_PROJECT_VERSION to at least {max_build + 1}."
+                )
+            elif not args.direct_upload and project_build <= max_build:
+                messages.append(
+                    "WARN: CURRENT_PROJECT_VERSION is not greater than the current train's highest uploaded build. "
+                    "This is acceptable only if Xcode Cloud is assigning its own build number and no direct upload will run."
+                )
+        else:
+            print(f"No uploaded builds found for {marketing_version}.")
+
+    blocked = [message for message in messages if message.startswith("BLOCKED:")]
+    warnings = [message for message in messages if message.startswith("WARN:")]
+    for message in messages:
+        print(message)
+
+    if blocked:
+        return 1
+    if warnings:
+        return 0
+
+    print("OK: Cubby Xcode Cloud/TestFlight version preflight passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except RuntimeError as error:
+        print(f"BLOCKED: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,12 +148,19 @@ xcrun simctl launch booted com.barronroth.Cubby DISABLE_CLOUDKIT
 - Use Xcode Cloud when local archive/signing is blocked by keychain or certificate access.
 - `.asc/export-options-app-store.plist` contains App Store Connect export options for local `asc`/Xcode export flows.
 - Version/build numbers are release-sensitive. Before opening or updating any PR branch that can trigger Xcode Cloud/TestFlight/App Store distribution:
+  - Use the repo-local `cubby-xcloud-pr-preflight` skill and run:
+    `python3 .agents/skills/cubby-xcloud-pr-preflight/scripts/preflight.py`
+    Add `--direct-upload` when a local ASC/TestFlight upload will run.
   - Read the project values from `Cubby.xcodeproj/project.pbxproj`:
     `rg -n "MARKETING_VERSION|CURRENT_PROJECT_VERSION" Cubby.xcodeproj/project.pbxproj`
+  - Check whether the current `MARKETING_VERSION` points at a closed App Store version train:
+    `ASC_BYPASS_KEYCHAIN=1 asc versions list --app 6751732388 --platform IOS --output table`
+  - If the current `MARKETING_VERSION` is `READY_FOR_DISTRIBUTION`/`READY_FOR_SALE`, Xcode Cloud/TestFlight uploads for that train can fail even when the build number is unused. Bump all `MARKETING_VERSION` occurrences to the next intended patch version before pushing.
   - Check App Store Connect for already-uploaded builds:
-    `asc builds list --app 6751732388 --sort -uploadedDate --limit 20 --output table`
-  - Ensure `CURRENT_PROJECT_VERSION` is greater than every uploaded/submitted build for the same `MARKETING_VERSION`; if not, bump all `CURRENT_PROJECT_VERSION` occurrences to the next unused integer before pushing.
-  - Do not bump `MARKETING_VERSION` unless the user explicitly asks for a new App Store version or the release train requires it. For normal PR/TestFlight fixes, keep the current marketing version and only bump the build number.
+    `ASC_BYPASS_KEYCHAIN=1 asc builds list --app 6751732388 --sort -uploadedDate --limit 20 --output table`
+  - For direct local TestFlight uploads, ensure `CURRENT_PROJECT_VERSION` is greater than every uploaded/submitted build for the same `MARKETING_VERSION`; if not, bump all `CURRENT_PROJECT_VERSION` occurrences to the next unused integer before uploading.
+  - Do not assume every Xcode Cloud failure is a build-number collision. Closed version trains caused prior failures, while Xcode Cloud may assign a build number that differs from `CURRENT_PROJECT_VERSION`.
+  - Do not bump `MARKETING_VERSION` unless the user explicitly asks for a new App Store version or the release train requires it. For normal PR/TestFlight fixes on an open train, keep the current marketing version and only bump the build number when direct upload needs it.
   - After pushing, monitor Xcode Cloud from GitHub with `gh pr checks --watch=false`; if it fails, inspect the Xcode Cloud details before bumping again.
 - Branches intended to launch the Codex Xcode Cloud/TestFlight workflow should keep the `codex/` prefix.
 - `fastlane/` is legacy. Historically it provided:


### PR DESCRIPTION
## Summary
- Add a repo-local `cubby-xcloud-pr-preflight` skill for Cubby release PRs
- Add a deterministic preflight script that checks MARKETING_VERSION, CURRENT_PROJECT_VERSION, ASC version-train state, and direct-upload build number safety
- Update AGENTS.md so future Codex threads run the preflight before Xcode Cloud/TestFlight PR pushes

## Validation
- `uv run --with pyyaml python /Users/barron/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/cubby-xcloud-pr-preflight`
- `python3 .agents/skills/cubby-xcloud-pr-preflight/scripts/preflight.py --skip-asc`
- `python3 .agents/skills/cubby-xcloud-pr-preflight/scripts/preflight.py` blocks current main as expected because 1.0.10 is a closed App Store version train
- `python3 .agents/skills/cubby-xcloud-pr-preflight/scripts/preflight.py --project /Users/barron/Developer/Cubby-hard-paywall-trial/Cubby.xcodeproj/project.pbxproj` allows Xcode Cloud with a warning
- `python3 .agents/skills/cubby-xcloud-pr-preflight/scripts/preflight.py --project /Users/barron/Developer/Cubby-hard-paywall-trial/Cubby.xcodeproj/project.pbxproj --direct-upload` blocks direct upload as expected because build 109 already exists for 1.0.11

Note: this PR intentionally uses a non-codex branch so the tooling-only guardrail change does not trigger the Codex TestFlight Xcode Cloud workflow.